### PR TITLE
Handle parameters at the root endpoint level

### DIFF
--- a/sphinxcontrib/openapi.py
+++ b/sphinxcontrib/openapi.py
@@ -69,8 +69,8 @@ def _resolve_refs(uri, spec):
     return _do_resolve(spec)
 
 
-def _httpresource(endpoint, method, properties):
-    parameters = properties.get('parameters', [])
+def _httpresource(endpoint, method, properties, parameters):
+    parameters = parameters + properties.get('parameters', [])
     responses = properties['responses']
     indent = '   '
 
@@ -136,8 +136,9 @@ def openapi2httpdomain(spec, **options):
             )
 
     for endpoint in options.get('paths', spec['paths']):
-        for method, properties in spec['paths'][endpoint].items():
-            generators.append(_httpresource(endpoint, method, properties))
+        params = spec['paths'][endpoint].pop('parameters', [])
+        for method, props in spec['paths'][endpoint].items():
+            generators.append(_httpresource(endpoint, method, props, params))
 
     return iter(itertools.chain(*generators))
 


### PR DESCRIPTION
To bring sphinxcontrib more in line with Open API specification,
handle parameters at the endpoint level, and pass them down to
the individual methods. 

For example, the toolset will now be able to handle the following YAML:
```
  /users/{user_id}:
    parameters:
      - $ref: "#/parameters/user_id"
    get:
      . . . 
```
*(Note #7 must be merged to handle the above list)*

As specified in the Specification > Schema > Path Item Object > Fixed Fields section of http://swagger.io/specification/.
Fixes #8 

Signed-off-by: Zac Delventhal <zac@bitwise.io>