### PR TITLE
Make the extensions compatible with Sphinx 1.6

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,12 @@ Here you can see the list of changes between each 'sphinxcontrib-openapi'
 release.
 
 
+0.3.1 (2017-05-19)
+==================
+
+- Make 'sphinxcontrib-openapi' compatible with Sphinx 1.6.
+
+
 0.3.0 (2017-01-29)
 ==================
 

--- a/sphinxcontrib/openapi.py
+++ b/sphinxcontrib/openapi.py
@@ -17,13 +17,10 @@ import yaml
 import jsonschema
 
 from docutils import nodes
-from docutils.parsers.rst import directives
+from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import ViewList
 
-from sphinx.util.compat import Directive
 from sphinx.util.nodes import nested_parse_with_titles
-
-from sphinxcontrib import httpdomain
 
 
 # Dictionaries do not guarantee to preserve the keys order so when we load
@@ -214,6 +211,5 @@ class OpenApi(Directive):
 
 
 def setup(app):
-    if 'http' not in app.domains:
-        httpdomain.setup(app)
+    app.setup_extension('sphinxcontrib.httpdomain')
     app.add_directive('openapi', OpenApi)


### PR DESCRIPTION
In Sphinx 1.6 two changes have an affect on this extension:

 * The Sphinx instance has dropped `domain` attribute, so it's now
   impossible to check whether `http` domain is loaded or not using
   this attribute. Apparently, it's been considered private and one
   needs to use `app.setup_extension` method to guarantee that the
   extension we depend on is loaded.

 * Base `Directive` class from Sphinx utils has been deprecated and
   is already removed in master branch. Now it's recommended to use
   one from docutils.

Fixes #12