### PR TITLE
Fix KeyError when using OpenAPI v3 specification

### DIFF
--- a/sphinxcontrib/openapi.py
+++ b/sphinxcontrib/openapi.py
@@ -139,6 +139,9 @@ def _normalize_spec(spec, **options):
         for method in endpoint.values():
             method.setdefault('parameters', [])
             method['parameters'].extend(parameters)
+            # Set default parameter type to 'string' to support both v2 and v3
+            for parameter in method['parameters']:
+                parameter.setdefault('type', 'string')
 
 
 def openapi2httpdomain(spec, **options):


### PR DESCRIPTION
In v3, the parameters doesn't have a 'type' resulting in this error:
  File "sphinxcontrib/openapi.py", line 94, in _httpresource
    yield indent + ':param {type} {name}:'.format(**param)
  KeyError: 'type'

This change adds partial OpenAPI v3 support by adding a default
'string' type in the _normalize_spec function.