### PR TITLE
Openapi json schema

### DIFF
--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -84,6 +84,95 @@ class TestOpenApi2HttpDomain(object):
                   Resource ETag.
         ''').lstrip()
 
+    def test_basic_v3(self):
+        text = '\n'.join(openapi.openapi2httpdomain({
+            'openapi': '3.0.0',
+            'paths': {
+                '/resources/{kind}': {
+                    'get': {
+                        'summary': 'List Resources',
+                        'description': '~ some useful description ~',
+                        'parameters': [
+                            {
+                                'name': 'kind',
+                                'in': 'path',
+                                'schema': {'type': 'string'},
+                                'description': 'Kind of resource to list.',
+                            },
+                            {
+                                'name': 'limit',
+                                'in': 'query',
+                                'schema': {'type': 'integer'},
+                                'description': 'Show up to `limit` entries.',
+                            },
+                            {
+                                'name': 'If-None-Match',
+                                'in': 'header',
+                                'schema': {'type': 'string'},
+                                'description': 'Last known resource ETag.'
+                            },
+                        ],
+                        'requestBody': {
+                            'content': {
+                                'application/json':  {
+                                    'example': '{"foo2": "bar2"}'
+                                }
+                            }
+                        },
+                        'responses': {
+                            '200': {
+                                'description': 'An array of resources.',
+                                'content': {
+                                    'application/json': {
+                                        'example': '{"foo": "bar"}'
+                                    }
+                                }
+                            },
+                        },
+                    },
+                },
+            },
+        }))
+        open('/tmp/toto', 'w').write(text)
+        assert text == textwrap.dedent('''
+            .. http:get:: /resources/{kind}
+               :synopsis: List Resources
+
+               **List Resources**
+
+               ~ some useful description ~
+
+               :param string kind:
+                  Kind of resource to list.
+               :query integer limit:
+                  Show up to `limit` entries.
+
+               **Example request:**
+
+               .. sourcecode:: http
+
+                  GET /resources/{kind} HTTP/1.1
+                  Host: example.com
+                  Content-Type: application/json
+
+                  {"foo2": "bar2"}
+
+               :status 200:
+                  An array of resources.
+
+                  **Example response:**
+
+                  .. sourcecode:: http
+
+                     HTTP/1.1 200 OK
+                     Content-Type: application/json
+
+                     {"foo": "bar"}
+
+               :reqheader If-None-Match:
+                  Last known resource ETag.
+        ''').lstrip()
+
     def test_two_resources(self):
         spec = collections.defaultdict(collections.OrderedDict)
         spec['paths']['/resource_a'] = {


### PR DESCRIPTION
Convert openapi v3 schemaObject to sphinx httpdomain `:>json` directive 

spec:
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#schemaObject
https://sphinxcontrib-httpdomain.readthedocs.io/en/stable/#resource-fields